### PR TITLE
fix(settings): add missing ErrorBoundary component + jsdom test env

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check:all": "npm run lint && npm run format && npm run typecheck && npm run test"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/src/settings/ErrorBoundary.tsx
+++ b/src/settings/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends React.Component<{ children: React.ReactNode }, ErrorBoundaryState> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="text-red-400 p-4">
+          <h2>Something went wrong</h2>
+          <p>{this.state.error?.message}</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/settings/__tests__/ErrorBoundary.test.tsx
+++ b/src/settings/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ErrorBoundary from '../ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  it('renders children without error', () => {
+    render(
+      <ErrorBoundary>
+        <div>Test content</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Test content')).toBeDefined();
+  });
+
+  it('renders fallback UI when a child throws an error', () => {
+    const ThrowingComponent = () => {
+      throw new Error('Test error');
+    };
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeDefined();
+    expect(screen.getByText('Test error')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Resolves the pre-existing TS2307 on main: src/settings/App.tsx imports ErrorBoundary from ./ErrorBoundary but the file was never committed. This PR adds ErrorBoundary.tsx, its vitest test with the required // @vitest-environment jsdom directive (sibling convention), and the check:all script in package.json. Unblocks downstream Morph tasks by making npm run check:all green on main.